### PR TITLE
Allow HTTP_HOST to be set via #header

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -161,9 +161,9 @@ module Rack
         uri.path = "/#{uri.path}" unless uri.path[0] == ?/
         uri.host ||= @default_host
 
-        env["HTTP_HOST"] ||= [uri.host, uri.port].compact.join(":")
-
         env = default_env.merge(env)
+
+        env["HTTP_HOST"] ||= [uri.host, uri.port].compact.join(":")
 
         env.update("HTTPS" => "on") if URI::HTTPS === uri
         env["HTTP_X_REQUESTED_WITH"] = "XMLHttpRequest" if env[:xhr]

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -228,6 +228,13 @@ describe Rack::Test::Session do
 
       last_request.env["CONTENT_TYPE"].should == "application/json"
     end
+    
+    it "sets a Host to be sent with requests" do
+      header "Host", "www.example.ua"
+      request "/"
+
+      last_request.env["HTTP_HOST"].should == "www.example.ua"
+    end
 
     it "persists across multiple requests" do
       header "User-Agent", "Firefox"


### PR DESCRIPTION
Fixes regression introduced in v.0.5.5.
