### PR TITLE
`finish` should be called on the response

### DIFF
--- a/lib/rack/mock_session.rb
+++ b/lib/rack/mock_session.rb
@@ -30,6 +30,8 @@ module Rack
       status, headers, body = @app.call(@last_request.env)
 
       @last_response = MockResponse.new(status, headers, body, env["rack.errors"].flush)
+      @last_response.finish if @last_response.respond_to?(:finish)
+
       body.close if body.respond_to?(:close)
 
       cookie_jar.merge(last_response.headers["Set-Cookie"], uri)


### PR DESCRIPTION
The response defines a `finish` method so that it can perform post processing on the response.  We should call that method if it responds to finish.
