### PR TITLE
Nested parameters on multipart forms

### DIFF
--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -61,7 +61,7 @@ module Rack
                   flattened_params["#{k}[]#{subkey}"] = subvalue
                 }
               else
-                flattened_params["#{k}[]"] = value
+                flattened_params["#{k}[]"] = v
               end
 
             end


### PR DESCRIPTION
They were broken, value (the mapped array) was used rather then v (the block argument)
