### PR TITLE
Support for HTTP OPTIONS verb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.2)
-    rack (1.2.1)
+    rack (1.2.2)
     rspec (2.3.0)
       rspec-core (~> 2.3.0)
       rspec-expectations (~> 2.3.0)
@@ -11,8 +11,10 @@ GEM
     rspec-expectations (2.3.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.3.0)
-    sinatra (1.0)
-      rack (>= 1.0)
+    sinatra (1.2.3)
+      rack (~> 1.1)
+      tilt (< 2.0, >= 1.2.2)
+    tilt (1.2.2)
 
 PLATFORMS
   ruby

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -84,6 +84,15 @@ module Rack
         process_request(uri, env, &block)
       end
 
+      # Issue an OPTIONS request for the given URI. See #get
+      #
+      # Example:
+      #   options "/"
+      def options(uri, params = {}, env = {}, &block)
+        env = env_for(uri, env.merge(:method => "OPTIONS", :params => params))
+        process_request(uri, env, &block)
+      end
+
       # Issue a HEAD request for the given URI. See #get
       #
       # Example:

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -62,6 +62,7 @@ module Rack
         :post,
         :put,
         :delete,
+        :options,
         :head,
         :follow_redirect!,
         :header,

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -9,6 +9,10 @@ module Rack
         "meh"
       end
 
+      options "/" do
+        [200, {}, ""]
+      end
+
       get "/" do
         "Hello, GET: #{params.inspect}"
       end

--- a/spec/rack/test/multipart_spec.rb
+++ b/spec/rack/test/multipart_spec.rb
@@ -58,7 +58,7 @@ describe Rack::Test::Session do
       last_request.POST["foo"].should == "bar"
 
       if Rack::Test.encoding_aware_strings?
-        last_request.POST["utf8"].should == "\xE2\x98\x83".force_encoding("BINARY")
+        last_request.POST["utf8"].should == "☃"
       else
         last_request.POST["utf8"].should == "\xE2\x98\x83"
       end

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -325,7 +325,7 @@ describe Rack::Test::Session do
   describe "#last_response" do
     it "returns the most recent response" do
       request "/"
-      last_response["Content-Type"].should == "text/html"
+      last_response["Content-Type"].should == "text/html;charset=utf-8"
     end
 
     it "raises an error if no requests have been issued" do
@@ -455,6 +455,14 @@ describe Rack::Test::Session do
 
     def verb
       "delete"
+    end
+  end
+
+  describe "#options" do
+    it_should_behave_like "any #verb methods"
+
+    def verb
+      "options"
     end
   end
 end


### PR DESCRIPTION
The OPTIONS verb is in Sinatra now (and I had to test it in my app), so I added it to rack-test. I also upgraded the Gemfile.lock to the latest Sinatra.

The UTF trick in multipart_spec.rb was necessary to make rack-test work with Sinatra 1.2.3.

(I had to update a couple of tests dealing with encoding to make them work in Sinatra 1.2.3. I ran the tests under Ruby 1.8.7 and 1.9.2).
