### PR TITLE
Fix for Issue #34

### DIFF
--- a/lib/rack/mock_session.rb
+++ b/lib/rack/mock_session.rb
@@ -28,7 +28,7 @@ module Rack
       env["HTTP_COOKIE"] ||= cookie_jar.for(uri)
       @last_request = Rack::Request.new(env)
       status, headers, body = @app.call(@last_request.env)
-      headers["Referer"] = env["Referer"] || ""
+      headers["Referer"] = env["HTTP_REFERER"] || ""
 
       @last_response = MockResponse.new(status, headers, body, env["rack.errors"].flush)
       body.close if body.respond_to?(:close)

--- a/lib/rack/mock_session.rb
+++ b/lib/rack/mock_session.rb
@@ -28,6 +28,7 @@ module Rack
       env["HTTP_COOKIE"] ||= cookie_jar.for(uri)
       @last_request = Rack::Request.new(env)
       status, headers, body = @app.call(@last_request.env)
+      headers["Referer"] = env["Referer"] || ""
 
       @last_response = MockResponse.new(status, headers, body, env["rack.errors"].flush)
       body.close if body.respond_to?(:close)

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -160,7 +160,7 @@ module Rack
           raise Error.new("Last response was not a redirect. Cannot follow_redirect!")
         end
 
-        get(last_response["Location"])
+        get(last_response["Location"], {}, { "Referer" => last_request.url })
       end
 
     private

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -160,7 +160,7 @@ module Rack
           raise Error.new("Last response was not a redirect. Cannot follow_redirect!")
         end
 
-        get(last_response["Location"], {}, { "Referer" => last_request.url })
+        get(last_response["Location"], {}, { "HTTP_REFERER" => last_request.url })
       end
 
     private

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -292,6 +292,7 @@ describe Rack::Test::Session do
 
       last_response.should_not be_redirect
       last_response.body.should == "You've been redirected"
+      last_response.headers["Referer"].should eql("http://example.org/redirect")
     end
 
     it "does not include params when following the redirect" do


### PR DESCRIPTION
This adds a referer header to `get` requests done by `follow_redirect!`. This solves an issue for me where I was checking for `request.referer` in my controller in a Capybara test and it was consistently coming through `nil`.
