### PR TITLE
Show cookies

### DIFF
--- a/lib/rack/mock_session.rb
+++ b/lib/rack/mock_session.rb
@@ -24,6 +24,10 @@ module Rack
       cookie_jar.merge(cookie, uri)
     end
 
+    def cookies
+      @cookie_jar.to_array
+    end
+
     def request(uri, env)
       env["HTTP_COOKIE"] ||= cookie_jar.for(uri)
       @last_request = Rack::Request.new(env)

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -26,7 +26,7 @@ module Rack
       extend Forwardable
       include Rack::Test::Utils
 
-      def_delegators :@rack_mock_session, :clear_cookies, :set_cookie, :last_response, :last_request
+      def_delegators :@rack_mock_session, :cookies, :clear_cookies, :set_cookie, :last_response, :last_request
 
       # Creates a Rack::Test::Session for a given Rack app or Rack::MockSession.
       #

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -143,6 +143,20 @@ module Rack
         hash_for(uri).values.map { |c| c.raw }.join(';')
       end
 
+      # :api: private
+      def to_array
+        @cookies.map do | cookie |
+          {
+          :name => cookie.name,
+          :value => cookie.value,
+          :path => cookie.path,
+          :domain => cookie.domain,
+          :expires => cookie.expires,
+          :secure => cookie.secure?
+          }
+        end
+      end 
+
       def to_hash
         cookies = {}
 

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -66,6 +66,7 @@ module Rack
         :head,
         :follow_redirect!,
         :header,
+        :cookies,
         :set_cookie,
         :clear_cookies,
         :authorize,

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -5,7 +5,6 @@ describe Rack::Test::Session do
   context "cookies" do
     it "keeps a cookie jar" do
       get "/cookies/show"
-      p last_request.class
       check last_request.cookies.should == {}
 
       get "/cookies/set", "value" => "1"

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -5,6 +5,7 @@ describe Rack::Test::Session do
   context "cookies" do
     it "keeps a cookie jar" do
       get "/cookies/show"
+      p last_request.class
       check last_request.cookies.should == {}
 
       get "/cookies/set", "value" => "1"
@@ -149,6 +150,12 @@ describe Rack::Test::Session do
       set_cookie "value=10"
       get "/cookies/show"
       last_request.cookies.should == { "value" => "10" }
+    end
+
+    it "allow cookies to be read" do
+      set_cookie "value=10"
+      get "/cookies/show"
+      cookies.should == [{:path=>"", :value=>"10", :expires=>nil, :secure=>false, :domain=>"example.org", :name=>"value"}]
     end
 
     it "allows an array of cookies to be set" do


### PR DESCRIPTION
Hi,

I'll be completely up front and say that I have not used rack-test all that much, so apologies in advance if the changes in this request are in any way misguided, or I have misunderstood the api and this is unnecessary.  

It would be really nice to have an easy way to obtain a snapshot of cookies in the cookie jar.  This would then allow them to be easily manipulated in abstraction api's e.g. Capybara.

I think currently you would have to do something like:

``` ruby
browser.current_session.instance_variable_get(:@rack_mock_session).cookie_jar.instance_variable_get(:@cookies)
```

So this was an attempt to provide an 'easier' api for this.
