### PR TITLE
Allow setting HTTPS header with the #header method

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -267,7 +267,7 @@ module Rack
 
         @headers.each do |name, value|
           env_key = name.upcase.gsub("-", "_")
-          env_key = "HTTP_" + env_key unless "CONTENT_TYPE" == env_key
+          env_key = "HTTP_" + env_key unless ["CONTENT_TYPE", "HTTPS"].include? env_key
           converted_headers[env_key] = value
         end
 

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -229,6 +229,13 @@ describe Rack::Test::Session do
       last_request.env["CONTENT_TYPE"].should == "application/json"
     end
     
+    it "sets a HTTPS to be sent with requests" do
+      header "HTTPS", "on"
+      request "/"
+
+      last_request.env["HTTPS"].should == "on"
+    end
+
     it "sets a Host to be sent with requests" do
       header "Host", "www.example.ua"
       request "/"


### PR DESCRIPTION
Being able to set the HTTPS header with the #header method enables things like a simple cucumber step to simulate the use of an SSL connection in tests, e.g.:

Given /^I use ssl$/ do
  header "HTTPS", "on"
end

This patch makes the HTTPS header a special case like Content-Type, so that it doesn't get HTTP_ prepended to it.
