### PR TITLE
Fix support for params with arrays of hashes in multipart forms.

### DIFF
--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -58,7 +58,8 @@ module Rack
 
               if (v.is_a?(Hash))
                 build_multipart(v, false).each { |subkey, subvalue|
-                  flattened_params["#{k}[]#{subkey}"] = subvalue
+                  flattened_params["#{k}[]#{subkey}"] ||= []
+                  flattened_params["#{k}[]#{subkey}"] << subvalue
                 }
               else
                 flattened_params["#{k}[]"] = value


### PR DESCRIPTION
If you have a multipart form with a param that's an array of hashes each element overwrites the last and you end up an array only containing the last element.

This commit updates the build_multipart method to build an array of values rather than reassigning the new value over the old.
