### PR TITLE
Pending spec demonstrating correct handling of cookies that are set without a path

### DIFF
--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -55,6 +55,17 @@ module Rack
         "Set"
       end
 
+      post "/cookies/default-path" do
+        raise if params["value"].nil?
+
+        response.set_cookie "simple", params["value"]
+        "Set"
+      end
+
+      get "/cookies/default-path" do
+        response.cookies.inspect
+      end
+
       get "/cookies/delete" do
         response.delete_cookie "value"
       end

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -20,6 +20,16 @@ describe Rack::Test::Session do
       last_request.cookies.should == {}
     end
 
+    it "cookie path defaults to the uri of the document that was requested" do
+      pending "See issue rack-test github issue #50" do
+        post "/cookies/default-path", "value" => "cookie"
+        get "/cookies/default-path"
+        check last_request.cookies.should == { "simple"=>"cookie" }
+        get "/cookies/show"
+        check last_request.cookies.should == { }
+      end
+    end
+
     it "escapes cookie values" do
       jar = Rack::Test::CookieJar.new
       jar["value"] = "foo;abc"


### PR DESCRIPTION
Relevant spec is RFC 2109, section 4.3.1: Interpreting Set-Cookie:

"Path: Defaults to the path of the request URL that generated the
Set-Cookie response, up to, but not including, the right-most /."

Rack/test strips the entire final component of the URL instead of just
the right-most "/".
