### PR TITLE
Prevent truncation of path to empty string when Path attribute is not specified

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -13,16 +13,7 @@ module Rack
       # :api: private
       def initialize(raw, uri = nil, default_host = DEFAULT_HOST)
         @default_host = default_host
-
-        # http://tools.ietf.org/html/rfc6265#section-5.1.4
         uri ||= default_uri
-        cookie_path = uri.path
-        if cookie_path.empty? || cookie_path[0] != '/' ||
-                                 cookie_path.count('/') < 2
-          cookie_path = '/'
-        else
-          cookie_path.sub!(/\/[^\/]*\Z/, "")
-        end
 
         # separate the name / value pair from the cookie options
         @name_value_raw, options = raw.split(/[;,] */n, 2)
@@ -31,7 +22,18 @@ module Rack
         @options = parse_query(options, ';')
 
         @options["domain"]  ||= (uri.host || default_host)
-        @options["path"]    ||= cookie_path
+
+        unless @options.has_key?("path")
+          # http://tools.ietf.org/html/rfc6265#section-5.1.4
+          cookie_path = uri.path
+          if cookie_path.empty? || cookie_path[0] != '/' ||
+                                   cookie_path.count('/') < 2
+            cookie_path = '/'
+          else
+            cookie_path.sub!(/\/[^\/]*\Z/, "")
+          end
+          @options["path"] = cookie_path
+        end
       end
 
       def replaces?(other)

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -13,7 +13,16 @@ module Rack
       # :api: private
       def initialize(raw, uri = nil, default_host = DEFAULT_HOST)
         @default_host = default_host
+
+        # http://tools.ietf.org/html/rfc6265#section-5.1.4
         uri ||= default_uri
+        cookie_path = uri.path
+        if cookie_path.empty? || cookie_path[0] != '/' ||
+                                 cookie_path.count('/') < 2
+          cookie_path = '/'
+        else
+          cookie_path.sub!(/\/[^\/]*\Z/, "")
+        end
 
         # separate the name / value pair from the cookie options
         @name_value_raw, options = raw.split(/[;,] */n, 2)
@@ -22,7 +31,7 @@ module Rack
         @options = parse_query(options, ';')
 
         @options["domain"]  ||= (uri.host || default_host)
-        @options["path"]    ||= uri.path.sub(/\/[^\/]*\Z/, "")
+        @options["path"]    ||= cookie_path
       end
 
       def replaces?(other)

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -29,6 +29,18 @@ module Rack
         [200, {}, ""]
       end
 
+      get "/set-default-path" do
+        raise if params["value"].nil?
+
+        response.set_cookie "value", :value => params["value"]
+      end
+
+      get "/set-forced-path" do
+        raise if params["value"].nil?
+
+        response.set_cookie "value", :value => params["value"], :path => '/'
+      end
+
       get "/cookies/show" do
         request.cookies.inspect
       end

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -20,16 +20,6 @@ describe Rack::Test::Session do
       last_request.cookies.should == {}
     end
 
-    it "cookie path defaults to the uri of the document that was requested" do
-      pending "See issue rack-test github issue #50" do
-        post "/cookies/default-path", "value" => "cookie"
-        get "/cookies/default-path"
-        check last_request.cookies.should == { "simple"=>"cookie" }
-        get "/cookies/show"
-        check last_request.cookies.should == { }
-      end
-    end
-
     it "escapes cookie values" do
       jar = Rack::Test::CookieJar.new
       jar["value"] = "foo;abc"
@@ -110,10 +100,16 @@ describe Rack::Test::Session do
       last_request.cookies.should == {}
     end
 
-    it "defaults the domain to the request path up to the last slash" do
+    it "defaults the path to the request path up to the last slash" do
       get "/cookies/set-simple", "value" => "1"
       get "/not-cookies/show"
       last_request.cookies.should == {}
+    end
+
+    it "defaults the path to '/' when path is not explicitly set" do
+      get "/set-forced-path", "value" => "1"
+      get "/set-default-path", "value" => "2"
+      rack_mock_session.cookie_jar['value'].should == "2"
     end
 
     it "supports secure cookies" do


### PR DESCRIPTION
Ref: brynary/rack-test#50
