### PR TITLE
Don't append default ports to HTTP_HOST

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -182,7 +182,7 @@ module Rack
 
         env = default_env.merge(env)
 
-        env["HTTP_HOST"] ||= [uri.host, uri.port].compact.join(":")
+        env["HTTP_HOST"] ||= [uri.host, (uri.port if uri.port != uri.default_port)].compact.join(":")
 
         env.update("HTTPS" => "on") if URI::HTTPS === uri
         env["HTTP_X_REQUESTED_WITH"] = "XMLHttpRequest" if env[:xhr]

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -34,6 +34,22 @@ describe Rack::Test::Session do
       last_request.env['HTTP_HOST'].should == "www.example.ua"
     end
 
+    it "sets HTTP_HOST with port for non-default ports" do
+      request "http://foo.com:8080"
+      last_request.env["HTTP_HOST"].should == "foo.com:8080"
+      request "https://foo.com:8443"
+      last_request.env["HTTP_HOST"].should == "foo.com:8443"
+    end
+
+    it "sets HTTP_HOST without port for default ports" do
+      request "http://foo.com"
+      last_request.env["HTTP_HOST"].should == "foo.com"
+      request "http://foo.com:80"
+      last_request.env["HTTP_HOST"].should == "foo.com"
+      request "https://foo.com:443"
+      last_request.env["HTTP_HOST"].should == "foo.com"
+    end
+
     it "defaults to GET" do
       request "/"
       last_request.env["REQUEST_METHOD"].should == "GET"


### PR DESCRIPTION
This is in accordance with common behavior.

Right now, if you do `request("http://localhost")`, it will set `HTTP_HOST` to `"localhost:80"`.

The correct behavior is to set `HTTP_HOST` to `"localhost"`.
