### PR TITLE
Preserve the exact query string when possible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'rspec'
 gem "rack"
 gem "sinatra"
 gem 'rake'
+gem 'ruby-debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,15 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    columnize (0.3.4)
     diff-lcs (1.1.3)
+    linecache (0.46)
+      rbx-require-relative (> 0.0.4)
     rack (1.4.0)
     rack-protection (1.2.0)
       rack
     rake (0.9.2)
+    rbx-require-relative (0.0.5)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
       rspec-expectations (~> 2.8.0)
@@ -14,6 +18,11 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
+    ruby-debug (0.10.4)
+      columnize (>= 0.1)
+      ruby-debug-base (~> 0.10.4.0)
+    ruby-debug-base (0.10.4)
+      linecache (>= 0.3)
     sinatra (1.3.2)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
@@ -28,4 +37,5 @@ DEPENDENCIES
   rack
   rake
   rspec
+  ruby-debug
   sinatra

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -192,10 +192,12 @@ module Rack
         env["REQUEST_METHOD"] ||= env[:method] ? env[:method].to_s.upcase : "GET"
 
         if env["REQUEST_METHOD"] == "GET"
-          params = env[:params] || {}
-          params = parse_nested_query(params) if params.is_a?(String)
-          params.update(parse_nested_query(uri.query))
-          uri.query = build_nested_query(params)
+          # merge :params with the query string
+          if params = env[:params]
+            params = parse_nested_query(params) if params.is_a?(String)
+            params.update(parse_nested_query(uri.query))
+            uri.query = build_nested_query(params)
+          end
         elsif !env.has_key?(:input)
           env["CONTENT_TYPE"] ||= "application/x-www-form-urlencoded"
 

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -115,6 +115,12 @@ module Rack
         merge("#{name}=#{Rack::Utils.escape(value)}")
       end
 
+      def delete(name)
+        @cookies.reject! do |cookie|
+          cookie.name == name
+        end
+      end
+
       def merge(raw_cookies, uri = nil)
         return unless raw_cookies
 

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -36,6 +36,14 @@ describe Rack::Test::Session do
       jar["value"].should == "foo;abc"
     end
 
+    it "deletes cookies directly from the CookieJar" do
+      jar = Rack::Test::CookieJar.new
+      jar["abcd"] = "1234"
+      jar["abcd"].should == "1234"
+      jar.delete("abcd")
+      jar["abcd"].should == nil
+    end
+
     it "doesn't send cookies with the wrong domain" do
       get "http://www.example.com/cookies/set", "value" => "1"
       get "http://www.other.example/cookies/show"

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -106,6 +106,11 @@ describe Rack::Test::Session do
       last_request.GET.should == { "baz" => "2", "foo" => { "bar" => "1" }}
     end
 
+    it "does not rewrite a GET query string when :params is not supplied" do
+      request "/foo?a=1&b=2&c=3&e=4&d=5"
+      last_request.query_string.should == "a=1&b=2&c=3&e=4&d=5"
+    end
+
     it "accepts params and builds url encoded params for POST requests" do
       request "/foo", :method => :post, :params => {:foo => {:bar => "1"}}
       last_request.env["rack.input"].read.should == "foo[bar]=1"


### PR DESCRIPTION
This little change allows integration testing to work when the exact query string matters.  This is important, for example, for testing payments with Braintree, where the query string is verified using a hashing technique.  It should also provide a slight performance benefit for people testing with a lot of explicit query strings.
