### PR TITLE
Preserve the exact query string when possible and add a delete method to CookieJar

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -192,10 +192,12 @@ module Rack
         env["REQUEST_METHOD"] ||= env[:method] ? env[:method].to_s.upcase : "GET"
 
         if env["REQUEST_METHOD"] == "GET"
-          params = env[:params] || {}
-          params = parse_nested_query(params) if params.is_a?(String)
-          params.update(parse_nested_query(uri.query))
-          uri.query = build_nested_query(params)
+          # merge :params with the query string
+          if params = env[:params]
+            params = parse_nested_query(params) if params.is_a?(String)
+            params.update(parse_nested_query(uri.query))
+            uri.query = build_nested_query(params)
+          end
         elsif !env.has_key?(:input)
           env["CONTENT_TYPE"] ||= "application/x-www-form-urlencoded"
 

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -115,6 +115,12 @@ module Rack
         merge("#{name}=#{Rack::Utils.escape(value)}")
       end
 
+      def delete(name)
+        @cookies.reject! do |cookie|
+          cookie.name == name
+        end
+      end
+
       def merge(raw_cookies, uri = nil)
         return unless raw_cookies
 

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -36,6 +36,14 @@ describe Rack::Test::Session do
       jar["value"].should == "foo;abc"
     end
 
+    it "deletes cookies directly from the CookieJar" do
+      jar = Rack::Test::CookieJar.new
+      jar["abcd"] = "1234"
+      jar["abcd"].should == "1234"
+      jar.delete("abcd")
+      jar["abcd"].should == nil
+    end
+
     it "doesn't send cookies with the wrong domain" do
       get "http://www.example.com/cookies/set", "value" => "1"
       get "http://www.other.example/cookies/show"

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -106,6 +106,11 @@ describe Rack::Test::Session do
       last_request.GET.should == { "baz" => "2", "foo" => { "bar" => "1" }}
     end
 
+    it "does not rewrite a GET query string when :params is not supplied" do
+      request "/foo?a=1&b=2&c=3&e=4&d=5"
+      last_request.query_string.should == "a=1&b=2&c=3&e=4&d=5"
+    end
+
     it "accepts params and builds url encoded params for POST requests" do
       request "/foo", :method => :post, :params => {:foo => {:bar => "1"}}
       last_request.env["rack.input"].read.should == "foo[bar]=1"


### PR DESCRIPTION
1. A small change allows integration testing to work when the exact query string matters. This is important, for example, for testing payments with Braintree, where the query string is verified using a hashing technique. It should also provide a slight performance benefit for people testing with a lot of explicit query strings.
2. On versions of Rails < 3, you could do cookies.delete(name), which was useful in simulating events like the user closing his browser.  The latest commit in this pull request makes that possible again. 
