### PR TITLE
Allow testers to request the tempfile attribute.

### DIFF
--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -14,6 +14,9 @@ module Rack
       # The filename, *not* including the path, of the "uploaded" file
       attr_reader :original_filename
 
+      # The tempfile
+      attr_reader :tempfile
+
       # The content type of the "uploaded" file
       attr_accessor :content_type
 

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -17,6 +17,8 @@ describe Rack::Test::UploadedFile do
     uploaded_file.should respond_to(:size)
     uploaded_file.should respond_to(:unlink)
     uploaded_file.should respond_to(:read)
+    uploaded_file.should respond_to(:original_filename)
+    uploaded_file.should respond_to(:tempfile) # Allows calls to params[:file].tempfile
   end
 
 end


### PR DESCRIPTION
This will fix error and solutions such as those mentioned in http://stackoverflow.com/questions/7793510/mocking-file-uploads-in-rails-3-1-controller-tests and http://www.ruby-forum.com/topic/2472338#1019355
