### PR TITLE
Provide full support for arrays of hashes in multipart forms

### DIFF
--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -58,7 +58,8 @@ module Rack
 
               if (v.is_a?(Hash))
                 build_multipart(v, false).each { |subkey, subvalue|
-                  flattened_params["#{k}[]#{subkey}"] = subvalue
+                  flattened_params["#{k}[]#{subkey}"] ||= []
+                  flattened_params["#{k}[]#{subkey}"] << subvalue
                 }
               else
                 flattened_params["#{k}[]"] = value

--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -59,7 +59,7 @@ module Rack
               if (v.is_a?(Hash))
                 nested_params = {}
                 build_multipart(v, false).each { |subkey, subvalue|
-                  nested_params["#{k}[]#{subkey}"] = subvalue
+                  nested_params[subkey] = subvalue
                 }
                 flattened_params["#{k}[]"] ||= []
                 flattened_params["#{k}[]"] << nested_params
@@ -94,7 +94,11 @@ module Rack
       def get_parts(parameters)
         parameters.map { |name, value|
           if name =~ /\[\]$/ && value.is_a?(Array) && value.all? {|v| v.is_a?(Hash)}
-            value.map {|v| get_parts(v).join}.join
+            value.map { |hash|
+              new_value = {}
+              hash.each { |k, v| new_value[name+k] = v }
+              get_parts(new_value).join
+            }.join
           else
             if value.respond_to?(:original_filename)
               build_file_part(name, value)

--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -57,10 +57,12 @@ module Rack
             value.map do |v|
 
               if (v.is_a?(Hash))
+                nested_params = {}
                 build_multipart(v, false).each { |subkey, subvalue|
-                  flattened_params["#{k}[]#{subkey}"] ||= []
-                  flattened_params["#{k}[]#{subkey}"] << subvalue
+                  nested_params["#{k}[]#{subkey}"] = subvalue
                 }
+                flattened_params["#{k}[]"] ||= []
+                flattened_params["#{k}[]"] << nested_params
               else
                 flattened_params["#{k}[]"] = value
               end
@@ -86,21 +88,28 @@ module Rack
 
     private
       def build_parts(parameters)
+        get_parts(parameters).join + "--#{MULTIPART_BOUNDARY}--\r"
+      end
+
+      def get_parts(parameters)
         parameters.map { |name, value|
-          if value.respond_to?(:original_filename)
-            build_file_part(name, value)
-
-          elsif value.is_a?(Array) and value.all? { |v| v.respond_to?(:original_filename) }
-            value.map do |v|
-              build_file_part(name, v)
-            end.join
-
+          if name =~ /\[\]$/ && value.is_a?(Array) && value.all? {|v| v.is_a?(Hash)}
+            value.map {|v| get_parts(v).join}.join
           else
-            primitive_part = build_primitive_part(name, value)
-            Rack::Test.encoding_aware_strings? ? primitive_part.force_encoding('BINARY') : primitive_part
-          end
+            if value.respond_to?(:original_filename)
+              build_file_part(name, value)
 
-        }.join + "--#{MULTIPART_BOUNDARY}--\r"
+            elsif value.is_a?(Array) and value.all? { |v| v.respond_to?(:original_filename) }
+              value.map do |v|
+                build_file_part(name, v)
+              end.join
+
+            else
+              primitive_part = build_primitive_part(name, value)
+              Rack::Test.encoding_aware_strings? ? primitive_part.force_encoding('BINARY') : primitive_part
+            end
+          end
+        }
       end
 
       def build_primitive_part(parameter_name, value)

--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -93,7 +93,7 @@ module Rack
 
       def get_parts(parameters)
         parameters.map { |name, value|
-          if name =~ /\[\]$/ && value.is_a?(Array) && value.all? {|v| v.is_a?(Hash)}
+          if name =~ /\[\]\Z/ && value.is_a?(Array) && value.all? {|v| v.is_a?(Hash)}
             value.map { |hash|
               new_value = {}
               hash.each { |k, v| new_value[name+k] = v }

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -120,6 +120,26 @@ describe Rack::Test::Utils do
       check params["foo"].should == [{"id" => "1", "name" => "Dave"}, {"id" => "2", "name" => "Steve"}]
     end
 
+    it "builds nested multipart bodies with arbitrarily nested array of hashes" do
+      files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
+      data  = build_multipart("files" => files, "foo" => {"bar" => [{"id" => "1", "name" => 'Dave'},
+                                                                    {"id" => "2", "name" => 'Steve', "qux" => [{"id" => '3', "name" => 'mike'},
+                                                                                                               {"id" => '4', "name" => 'Joan'}]}]})
+
+      options = {
+        "CONTENT_TYPE" => "multipart/form-data; boundary=#{Rack::Test::MULTIPART_BOUNDARY}",
+        "CONTENT_LENGTH" => data.length.to_s,
+        :input => StringIO.new(data)
+      }
+      env = Rack::MockRequest.env_for("/", options)
+      params = Rack::Utils::Multipart.parse_multipart(env)
+      check params["files"][:filename].should == "foo.txt"
+      params["files"][:tempfile].read.should == "bar\n"
+      check params["foo"].should == {"bar" => [{"id" => "1", "name" => "Dave"},
+                                               {"id" => "2", "name" => "Steve", "qux" => [{"id" => '3', "name" => 'mike'},
+                                                                                          {"id" => '4', "name" => 'Joan'}]}]}
+    end
+
     it "returns nil if no UploadedFiles were used" do
       data = build_multipart("people" => [{"submit-name" => "Larry", "files" => "contents"}])
       data.should be_nil

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -106,7 +106,7 @@ describe Rack::Test::Utils do
 
     it "builds nested multipart bodies with an array of hashes" do
       files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
-      data  = build_multipart("files" => files, "foo" => [{"id" => "1"}, {"id" => "2"}])
+      data  = build_multipart("files" => files, "foo" => [{"id" => "1", "name" => 'Dave'}, {"id" => "2", "name" => 'Steve'}])
 
       options = {
         "CONTENT_TYPE" => "multipart/form-data; boundary=#{Rack::Test::MULTIPART_BOUNDARY}",
@@ -117,7 +117,7 @@ describe Rack::Test::Utils do
       params = Rack::Utils::Multipart.parse_multipart(env)
       check params["files"][:filename].should == "foo.txt"
       params["files"][:tempfile].read.should == "bar\n"
-      check params["foo"].should == [{"id" => "1"}, {"id" => "2"}]
+      check params["foo"].should == [{"id" => "1", "name" => "Dave"}, {"id" => "2", "name" => "Steve"}]
     end
 
     it "returns nil if no UploadedFiles were used" do

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -140,6 +140,41 @@ describe Rack::Test::Utils do
                                                                                           {"id" => '4', "name" => 'Joan'}]}]}
     end
 
+    it 'does not break with params that look nested, but are not' do
+      files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
+      data  = build_multipart("foo[]" => "1", "bar[]" => {"qux" => "2"}, "files[]" => files)
+
+      options = {
+        "CONTENT_TYPE" => "multipart/form-data; boundary=#{Rack::Test::MULTIPART_BOUNDARY}",
+        "CONTENT_LENGTH" => data.length.to_s,
+        :input => StringIO.new(data)
+      }
+      env = Rack::MockRequest.env_for("/", options)
+      params = Rack::Utils::Multipart.parse_multipart(env)
+      check params["files"][0][:filename].should == "foo.txt"
+      params["files"][0][:tempfile].read.should == "bar\n"
+      check params["foo"][0].should == "1"
+      check params["bar"][0].should == {"qux" => "2"}
+    end
+
+    it 'allows for nested files' do
+      files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
+      data  = build_multipart("foo" => [{"id" => "1", "data" => files},
+                                        {"id" => "2", "data" => ["3", "4"]}])
+
+      options = {
+        "CONTENT_TYPE" => "multipart/form-data; boundary=#{Rack::Test::MULTIPART_BOUNDARY}",
+        "CONTENT_LENGTH" => data.length.to_s,
+        :input => StringIO.new(data)
+      }
+      env = Rack::MockRequest.env_for("/", options)
+      params = Rack::Utils::Multipart.parse_multipart(env)
+      check params["foo"][0]["id"].should == "1"
+      check params["foo"][0]["data"][:filename].should == "foo.txt"
+      params["foo"][0]["data"][:tempfile].read.should == "bar\n"
+      check params["foo"][1].should == {"id" => "2", "data" => ["3", "4"]}
+    end
+
     it "returns nil if no UploadedFiles were used" do
       data = build_multipart("people" => [{"submit-name" => "Larry", "files" => "contents"}])
       data.should be_nil


### PR DESCRIPTION
The @econsultancy fix (#41) only partially fixed the problem.  If the hashes had more than one key they would be rendered so that all the values for a given subkey would be together.  

e.g.  given:

```
blah: [{id: 1, name: 'dave'}, {id: 2, name: 'steve'}]
```

then the multipart rendering would be

```
------------XnJLe9ZIbbGUYtzPQJ16u1
Content-Disposition: form-data; name="blah[][id]"

1
------------XnJLe9ZIbbGUYtzPQJ16u1
Content-Disposition: form-data; name="blah[][id]"

2
------------XnJLe9ZIbbGUYtzPQJ16u1
Content-Disposition: form-data; name="blah[][name]"

dave
------------XnJLe9ZIbbGUYtzPQJ16u1
Content-Disposition: form-data; name="blah[][name]"

steve
```

which is then parsed out as:

```
blah: [{id: 1}, {name: 'dave', id: 2}, {name: 'steve'}]
```

We've fixed it so that the values for each hash are rendered next to each other.  So the multipart rendering is:

```
------------XnJLe9ZIbbGUYtzPQJ16u1
Content-Disposition: form-data; name="blah[][id]"

1
------------XnJLe9ZIbbGUYtzPQJ16u1
Content-Disposition: form-data; name="blah[][name]"

dave
------------XnJLe9ZIbbGUYtzPQJ16u1
Content-Disposition: form-data; name="blah[][id]"

2
------------XnJLe9ZIbbGUYtzPQJ16u1
Content-Disposition: form-data; name="blah[][name]"

steve
```

and this is parsed out properly to:

```
blah: [{id: 1, name: 'dave'}, {id: 2, name: 'steve'}]
```
