### PR TITLE
add license information to the gemspec

### DIFF
--- a/rack-test.gemspec
+++ b/rack-test.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Bryan Helmkamp"]
   s.date = "2012-09-27"
+  s.license = "MIT"
   s.description = "Rack::Test is a small, simple testing API for Rack apps. It can be used on its\nown or as a reusable starting point for Web frameworks and testing libraries\nto build on. Most of its initial functionality is an extraction of Merb 1.0's\nrequest helpers feature."
   s.email = "bryan@brynary.com"
   s.extra_rdoc_files = [


### PR DESCRIPTION
this way we can use it when using rubygems.org API
