### PR TITLE
Allow for custom env settings to be set and simple csrf support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rspec'
 gem "rack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,24 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    rack (1.4.0)
-    rack-protection (1.2.0)
+    diff-lcs (1.2.3)
+    rack (1.5.2)
+    rack-protection (1.5.0)
       rack
-    rake (0.9.2)
-    rspec (2.8.0)
-      rspec-core (~> 2.8.0)
-      rspec-expectations (~> 2.8.0)
-      rspec-mocks (~> 2.8.0)
-    rspec-core (2.8.0)
-    rspec-expectations (2.8.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.8.0)
-    sinatra (1.3.2)
-      rack (~> 1.3, >= 1.3.6)
-      rack-protection (~> 1.2)
-      tilt (~> 1.3, >= 1.3.3)
-    tilt (1.3.3)
+    rake (10.0.4)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
+    sinatra (1.4.2)
+      rack (~> 1.5, >= 1.5.2)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.3.7)
 
 PLATFORMS
   java

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -187,12 +187,6 @@ module Rack
         get(last_response["Location"], {}, { "HTTP_REFERER" => last_request.url })
       end
 
-      # Set a CSRF token so you can easily test safe services
-      def csrf(enable=true)
-        header('X-CSRF-Token', enable ? 'token' : nil)
-        env('rack.session', enable ? {:csrf => 'token'} : nil)
-      end
-
     private
 
       def env_for(path, env)

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -4,8 +4,7 @@ require "rack/mock_session"
 require "rack/test/cookie_jar"
 require "rack/test/mock_digest_request"
 require "rack/test/utils"
-load '/Users/daris/Documents/uxtemple/opensource/rack-test/lib/rack/test/methods.rb'
-# require "rack/test/methods"
+require "rack/test/methods"
 require "rack/test/uploaded_file"
 
 module Rack

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -67,11 +67,13 @@ module Rack
         :head,
         :follow_redirect!,
         :header,
+        :env,
         :set_cookie,
         :clear_cookies,
         :authorize,
         :basic_authorize,
         :digest_authorize,
+        :csrf,
         :last_response,
         :last_request
       ]

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -73,7 +73,6 @@ module Rack
         :authorize,
         :basic_authorize,
         :digest_authorize,
-        :csrf,
         :last_response,
         :last_request
       ]

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -237,10 +237,10 @@ describe Rack::Test::Session do
 
   describe "#header" do
     it "sets a header to be sent with requests" do
-      header "User-Agent", "token"
+      header "User-Agent", "Firefox"
       request "/"
 
-      last_request.env["HTTP_USER_AGENT"].should == "token"
+      last_request.env["HTTP_USER_AGENT"].should == "Firefox"
     end
 
     it "sets a Content-Type to be sent with requests" do
@@ -258,15 +258,15 @@ describe Rack::Test::Session do
     end
 
     it "persists across multiple requests" do
-      header "User-Agent", "token"
+      header "User-Agent", "Firefox"
       request "/"
       request "/"
 
-      last_request.env["HTTP_USER_AGENT"].should == "token"
+      last_request.env["HTTP_USER_AGENT"].should == "Firefox"
     end
 
     it "overwrites previously set headers" do
-      header "User-Agent", "token"
+      header "User-Agent", "Firefox"
       header "User-Agent", "Safari"
       request "/"
 
@@ -274,7 +274,7 @@ describe Rack::Test::Session do
     end
 
     it "can be used to clear a header" do
-      header "User-Agent", "token"
+      header "User-Agent", "Firefox"
       header "User-Agent", nil
       request "/"
 
@@ -282,7 +282,7 @@ describe Rack::Test::Session do
     end
 
     it "is overridden by headers sent during the request" do
-      header "User-Agent", "token"
+      header "User-Agent", "Firefox"
       request "/", "HTTP_USER_AGENT" => "Safari"
 
       last_request.env["HTTP_USER_AGENT"].should == "Safari"
@@ -375,44 +375,6 @@ describe Rack::Test::Session do
       lambda {
         follow_redirect!
       }.should raise_error(Rack::Test::Error)
-    end
-  end
-
-  describe "#csrf" do
-    it "sets the HTTP_X_CSRF_TOKEN header" do
-      csrf
-      request "/"
-
-      last_request.env["HTTP_X_CSRF_TOKEN"].should == "token"
-    end
-
-    it "sets the rack.session to include CSRF token" do
-      csrf
-      request "/"
-
-      last_request.env["rack.session"].should == {:csrf => "token"}
-    end
-
-    it "includes the header & rack.session for subsequent requests" do
-      csrf
-      request "/"
-      request "/"
-
-      last_request.env["HTTP_X_CSRF_TOKEN"].should == "token"
-      last_request.env["rack.session"].should == {:csrf => "token"}
-    end
-
-    it "can be cleared out" do
-      csrf
-      request "/"
-      last_request.env["HTTP_X_CSRF_TOKEN"].should == "token"
-      last_request.env["rack.session"].should == {:csrf => "token"}
-
-      csrf(false)
-      request "/"
-
-      last_request.env.should_not have_key("HTTP_X_CSRF_TOKEN")
-      last_request.env.should_not have_key("rack.session")
     end
   end
 


### PR DESCRIPTION
Hey @brynary,

How're things?

Helping @rex37 trying to come on board using Padrino we've come across [the need to test out controllers protected from CSRF](https://github.com/padrino/padrino-framework/issues/1016#issuecomment-16298422).

From the [rack-protection specs](https://github.com/rkh/rack-protection/blob/master/spec/authenticity_token_spec.rb#L10-L28) you can tell it's not that hard to do so but it clearly becomes a burden when you have to start setting all of that extra code `{'rack.session' => {:csrf => "b"}, 'HTTP_X_CSRF_TOKEN' => "b"})` for each unsafe method you test.

This PR intends to cover that along by adding a `csrf` helper that allows a user to do something as simple as:

```
before do
  csrf
end
```

and they can forget about csrf management for that test group until they clear it out with `csrf(false)`.

In order to have the validation work fine, I needed two things: a header and a session value. The header was taken care by `header` but I just couldn't find a way of setting the session value across all of the requests.
That is why I implemented an `env` method that allows you to set anything on the env object. I know this might sound risky but in all fairness, whomever is implementing the tests should know how to handle that.
However, there might be another way of doing it that I'm just not aware of.

What do you think about this?
Thanks! :)
